### PR TITLE
Restructure size package.

### DIFF
--- a/size.go
+++ b/size.go
@@ -1,100 +1,132 @@
+// Package size implements parsing for string values with units.
 package size
 
 import (
-	"flag"
 	"fmt"
 	"strconv"
 	"unicode"
 )
 
-// type size int64
-type Mapping map[string]int64
+// Sign is the sign associated with a unit's value.
+type Sign uint8
 
-type Size struct {
-	Size         int64 // Parsed size including sign
-	ExplicitSign int   // -1 if size string started with a '-', +1 if size string started with a '+', otherwise 0
-	Unit         string
-	str          string
-	mapping      Mapping
+const (
+	None Sign = iota
+	Negative
+	Positive
+)
+
+// Value is any value that can be represented by a unit.
+//
+// Value implements flag.Value and flag.Getter.
+type Value struct {
+	// unit is the associated unit.
+	unit *Unit
+
+	// value is the integer value.
+	value int64
+
+	// sign is the explicit sign given by the string converted to the
+	// integer.
+	sign Sign
 }
 
-func NewSize(size int64, unit string, mapping Mapping) Size {
-	s := Size{
-		Unit:    unit,
-		mapping: mapping,
-		str:     fmt.Sprintf("%d%s", size, unit),
-	}
+// Unit is a map of unit names to conversion multipliers.
+//
+// There must be a unit that maps to 1.
+type Unit struct {
+	mapping map[string]int64
+}
 
-	if sz, err := calcSize(size, unit, mapping); err != nil {
-		panic(err)
-	} else {
-		s.Size = sz
+func NewUnit(m map[string]int64) (*Unit, error) {
+	var found bool
+	for _, mult := range m {
+		if mult == 1 {
+			found = true
+		}
 	}
+	if !found {
+		return nil, fmt.Errorf("could not find unit that maps to multiplier 1 for %v", m)
+	}
+	return &Unit{m}, nil
+}
+
+func (u *Unit) NewValue(value int64, sign Sign) *Value {
+	return &Value{
+		value: value,
+		sign:  sign,
+		unit:  u,
+	}
+}
+
+func (u *Unit) ValueFromString(str string) (*Value, error) {
+	s := &Value{unit: u}
+
+	if err := s.Set(str); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// String implements flag.Value.String and fmt.Stringer.
+func (s Value) String() string {
+	var bestName string
+	bestMult := int64(1)
+	for name, mult := range s.unit.mapping {
+		if s.value%mult == 0 && mult >= bestMult {
+			bestName = name
+			bestMult = mult
+		}
+	}
+	var sign string
+	if s.sign == Negative {
+		sign = "-"
+	} else if s.sign == Positive {
+		sign = "+"
+	}
+	if bestName == "" {
+		return fmt.Sprintf("%s%d (no unit)", sign, s.value)
+	}
+	return fmt.Sprintf("%s%d%s", sign, s.value/bestMult, bestName)
+}
+
+// Get implements flag.Getter.Get.
+func (s Value) Get() interface{} {
 	return s
 }
 
-func (s Size) String() string {
-	return s.str
-}
-
-func calcSize(size int64, unit string, mapping Mapping) (int64, error) {
-	if unit == "" {
-		return size, nil
+// Set implements flag.Value.Set.
+func (s *Value) Set(str string) error {
+	if len(str) == 0 {
+		return fmt.Errorf("invalid size %q", str)
 	}
 
-	if m, ok := mapping[unit]; ok {
-		return size * int64(m), nil
-	} else {
-		return 0, fmt.Errorf("Unit %q is not valid", unit)
-	}
-}
-
-type sizeFlag struct{ Size }
-
-func (sf *sizeFlag) Set(s string) error {
-	if len(s) == 0 {
-		return fmt.Errorf("invalid size %q", s)
-	}
-
-	start, end := 0, len(s)
-	if s[0] == '+' {
-		sf.ExplicitSign = 1
+	start, end := 0, len(str)
+	if str[0] == '+' {
+		s.sign = Positive
 		start++
-	} else if s[0] == '-' {
-		sf.ExplicitSign = -1
+	} else if str[0] == '-' {
+		s.sign = Negative
 		start++
 	}
 
-	sf.Size.Unit = "" // reset the default one
-	for i, r := range s[start:] {
+	for i, r := range str[start:] {
 		if unicode.IsLetter(r) {
-			sf.Size.Unit = s[start+i:]
+			end = start + i
 			break
 		}
 	}
-	end -= len(sf.Size.Unit)
 
-	if end < start { // this really should not happen...
-		return fmt.Errorf("Internal parse error, end (%d) < start (%d)", end, start)
+	value, err := strconv.ParseInt(str[:end], 10, 64)
+	if err != nil {
+		return fmt.Errorf("could not convert %q to size: %v", str, err)
 	}
 
-	var parsed int64
-	var err error
-	if parsed, err = strconv.ParseInt(s[:end], 10, 64); err != nil { // do not use start, we want the sign
-		return fmt.Errorf("Could not convert %q to size: %v", s, err)
+	unitName := str[end:]
+	mult, ok := s.unit.mapping[unitName]
+	if !ok {
+		return fmt.Errorf("unit %q is not valid", unitName)
 	}
-	if sz, err := calcSize(parsed, sf.Size.Unit, sf.Size.mapping); err != nil {
-		return fmt.Errorf("Could not calculate size for %q: %v", s, err)
-	} else {
-		sf.Size.Size = sz
-	}
-
-	sf.str = s
+	s.value = value * mult
 	return nil
-}
-
-func Flag(name string, value Size, usage string) *Size {
-	f := sizeFlag{value}
-	flag.CommandLine.Var(&f, name, usage)
-	return &f.Size
 }


### PR DESCRIPTION
This is great! I'm just moving some code around and adding some comments.

- Implement flag.Getter for the Value function.
- Storing the value as both a string and an integer value is a redundant
  optimization and can easily lead to inconsistent state: we choose the
  integer and explicit sign representation and convert when necessary.

- Go programs shouldn't panic when they don't need to.
- Size and SizeFlag need not be separate structures, so they have been
  merged.
- The Flag function forces you to register the flag with
  flag.CommandLine. This is problematic for u-root, which rewrites a lot
  of source in bb mode and would currently be incompatible with that.
  Now that Size and SizeFlag are the same, one can call flag.Value
  rather than size.Flag.

Signed-off-by: Christopher Koch <chrisko@google.com>